### PR TITLE
Fix the under-constrained `ElGamalEncrypter`

### DIFF
--- a/circuits/el_gamal.circom
+++ b/circuits/el_gamal.circom
@@ -2,6 +2,7 @@ pragma circom 2.0.0;
 
 // copied from https://github.com/sigmachirality/empty-house
 
+include "../node_modules/circomlib/circuits/comparators.circom";
 include "./algebra.circom";
 
 // Card El Gamal encryption 
@@ -29,7 +30,10 @@ template ElGamalEncrypter(generator, bit_length){
     ciphertext[0] <== message[0] * exp1.out;     
     
     // Q: why do we need this? should we assert this before computing [0]?
-    assert(ciphertext[0] != 0);                        
+    // assert(ciphertext[0] != 0); 
+    component iz = IsZero();
+    iz.in <== ciphertext[0];
+    iz.out === 0;                       
     
     // c2 = c2 * h^y, adding g^{\sum xi}^y
     ciphertext[1] <== message[1] * exp2.out;     // 


### PR DESCRIPTION
The [`assert` statement](https://github.com/voidcenter/ew-zw/blob/ef5a7847932ce216fc241a76512678f39cc933be/circuits/el_gamal.circom#L32) in the `ElGamalEncrypter` circuit checks a condition during witness generation but does **not** enforce it as a constraint in the circuit. As a result, a malicious prover can supply a witness that violates the intended check while still satisfying all circuit constraints.

Close #1 

### Counterexample

Our fuzzing tool, [zkFuzz](https://github.com/Koukyosyumei/zkFuzz), discovered the following violating witness:

```
═══════════════╗
║🚨 Counter Example: ║
║ 🧟 UnderConstrained (Unexpected-Input) 🧟
║ Violated Condition: (NEq main.ciphertext[0] 0)
║ 🔍 Assignment Details:
║ ➡️ main.bit_length = 5
║ ➡️ main.generator = 3
║ ➡️ main.pk = 21888242871839275222246405745257275088548364400416034343698204186575808495588
║ ➡️ main.message[1] = 21888242871839275222246405745257275088548364400416034343698204186575808495575
║ ➡️ main.random_factor = 1
║ ➡️ main.ciphertext[1] = 1218
║ ➡️ main.message[0] = 0
║ ➡️ main.ciphertext[0] = 0
║ ➡️ main.exp1.base = 3
```

Despite `main.ciphertext[0]` being zero, the constraint system accepts this witness, revealing a correctness vulnerability.

---

### Fix

This issue is addressed by replacing the non-constraining `assert` with an actual constraint using Circomlib’s `IsZero` circuit, ensuring that `ciphertext[0]` is explicitly checked at constraint level.

---

### Acknowledgment

This vulnerability was first reported through a private channel.
@voidcenter, thank you for your swift response and for confirming the issue!
